### PR TITLE
fix: broken themes

### DIFF
--- a/.github/workflows/whiskers-check.yml
+++ b/.github/workflows/whiskers-check.yml
@@ -1,0 +1,15 @@
+name: whiskers
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  run:
+    uses: catppuccin/actions/.github/workflows/whiskers-check.yml@v1
+    with:
+      args: flow-launcher.tera
+    secrets: inherit

--- a/flow-launcher.tera
+++ b/flow-launcher.tera
@@ -1,7 +1,7 @@
 ---
 accent: mauve
 whiskers:
-  version: "2.3.0"
+  version: "^2.3.0"
   matrix:
     - flavor
   filename: "themes/Catppuccin {{ flavor.identifier | capitalize }}.xaml"
@@ -13,6 +13,10 @@ whiskers:
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/Themes/Win11Light.xaml" />
     </ResourceDictionary.MergedDictionaries>
+    <system:Boolean x:Key="ThemeBlurEnabled">True</system:Boolean>
+    <system:String x:Key="SystemBG">Auto</system:String>
+    <Color x:Key="LightBG">#{{mantle.hex}}</Color>
+    <Color x:Key="DarkBG">#{{mantle.hex}}</Color>
     <Style
         x:Key="ItemBulletSelectedStyle"
         BasedOn="{StaticResource ItemBulletSelectedStyle}"
@@ -31,6 +35,7 @@ whiskers:
         TargetType="{x:Type TextBox}">
         <Setter Property="Foreground" Value="#{{ text.hex }}" />
         <Setter Property="CaretBrush" Value="#{{ text.hex }}" />
+        <Setter Property="SelectionBrush" Value="#{{ flavor.colors[accent] | mix(color=base, amount=0.8) | get(key="hex") }}" />
     </Style>
     <Style
         x:Key="QuerySuggestionBoxStyle"

--- a/justfile
+++ b/justfile
@@ -1,5 +1,0 @@
-_default:
-  @just --list
-
-build:
-  whiskers flow-launcher.tera

--- a/themes/Catppuccin Frappe.xaml
+++ b/themes/Catppuccin Frappe.xaml
@@ -5,6 +5,10 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/Themes/Win11Light.xaml" />
     </ResourceDictionary.MergedDictionaries>
+    <system:Boolean x:Key="ThemeBlurEnabled">True</system:Boolean>
+    <system:String x:Key="SystemBG">Auto</system:String>
+    <Color x:Key="LightBG">#292c3c</Color>
+    <Color x:Key="DarkBG">#292c3c</Color>
     <Style
         x:Key="ItemBulletSelectedStyle"
         BasedOn="{StaticResource ItemBulletSelectedStyle}"
@@ -23,6 +27,7 @@
         TargetType="{x:Type TextBox}">
         <Setter Property="Foreground" Value="#c6d0f5" />
         <Setter Property="CaretBrush" Value="#c6d0f5" />
+        <Setter Property="SelectionBrush" Value="#ac88c6" />
     </Style>
     <Style
         x:Key="QuerySuggestionBoxStyle"

--- a/themes/Catppuccin Latte.xaml
+++ b/themes/Catppuccin Latte.xaml
@@ -5,6 +5,10 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/Themes/Win11Light.xaml" />
     </ResourceDictionary.MergedDictionaries>
+    <system:Boolean x:Key="ThemeBlurEnabled">True</system:Boolean>
+    <system:String x:Key="SystemBG">Auto</system:String>
+    <Color x:Key="LightBG">#e6e9ef</Color>
+    <Color x:Key="DarkBG">#e6e9ef</Color>
     <Style
         x:Key="ItemBulletSelectedStyle"
         BasedOn="{StaticResource ItemBulletSelectedStyle}"
@@ -23,6 +27,7 @@
         TargetType="{x:Type TextBox}">
         <Setter Property="Foreground" Value="#4c4f69" />
         <Setter Property="CaretBrush" Value="#4c4f69" />
+        <Setter Property="SelectionBrush" Value="#9d5ef0" />
     </Style>
     <Style
         x:Key="QuerySuggestionBoxStyle"

--- a/themes/Catppuccin Macchiato.xaml
+++ b/themes/Catppuccin Macchiato.xaml
@@ -5,6 +5,10 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/Themes/Win11Light.xaml" />
     </ResourceDictionary.MergedDictionaries>
+    <system:Boolean x:Key="ThemeBlurEnabled">True</system:Boolean>
+    <system:String x:Key="SystemBG">Auto</system:String>
+    <Color x:Key="LightBG">#1e2030</Color>
+    <Color x:Key="DarkBG">#1e2030</Color>
     <Style
         x:Key="ItemBulletSelectedStyle"
         BasedOn="{StaticResource ItemBulletSelectedStyle}"
@@ -23,6 +27,7 @@
         TargetType="{x:Type TextBox}">
         <Setter Property="Foreground" Value="#cad3f5" />
         <Setter Property="CaretBrush" Value="#cad3f5" />
+        <Setter Property="SelectionBrush" Value="#a588d1" />
     </Style>
     <Style
         x:Key="QuerySuggestionBoxStyle"

--- a/themes/Catppuccin Mocha.xaml
+++ b/themes/Catppuccin Mocha.xaml
@@ -5,6 +5,10 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/Themes/Win11Light.xaml" />
     </ResourceDictionary.MergedDictionaries>
+    <system:Boolean x:Key="ThemeBlurEnabled">True</system:Boolean>
+    <system:String x:Key="SystemBG">Auto</system:String>
+    <Color x:Key="LightBG">#181825</Color>
+    <Color x:Key="DarkBG">#181825</Color>
     <Style
         x:Key="ItemBulletSelectedStyle"
         BasedOn="{StaticResource ItemBulletSelectedStyle}"
@@ -23,6 +27,7 @@
         TargetType="{x:Type TextBox}">
         <Setter Property="Foreground" Value="#cdd6f4" />
         <Setter Property="CaretBrush" Value="#cdd6f4" />
+        <Setter Property="SelectionBrush" Value="#a88bcf" />
     </Style>
     <Style
         x:Key="QuerySuggestionBoxStyle"


### PR DESCRIPTION
I wasn't sure on how to make our themes dynamic like the Win11Light.xaml that we're basing it on, but this actually seems to apply the themes now. Also makes sure we use the accent colour instead of the system accent for text selection.

Closes #14